### PR TITLE
Add the org dumper script

### DIFF
--- a/dumper/Dockerfile
+++ b/dumper/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.13 AS builder
+RUN go get -v github.com/athenianco/metadata-retrieval/examples/cmd
+
+FROM postgres:latest
+
+COPY --from=builder /go/bin/cmd /usr/local/bin/metadata-retrieval
+RUN apt-get update && apt-get install -y ca-certificates && apt-get clean && rm -rf /var/lib/apt/lists/*
+COPY ghsync.sh /usr/local/bin
+
+CMD ["ghsync.sh"]

--- a/dumper/ghsync.sh
+++ b/dumper/ghsync.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+
+if [ -z "$ORGS" ]; then
+  ORGS=athenianco
+fi
+
+POSTGRES_PASSWORD=postgres docker-entrypoint.sh postgres &
+while ! : &>/dev/null </dev/tcp/127.0.0.1/5432; do
+  sleep 1
+done
+metadata-retrieval ghsync --version 1 --orgs=$ORGS --no-forks --db=postgres://postgres:postgres@127.0.0.1:5432/postgres?sslmode=disable
+pg_dump -U postgres -d postgres -f /io/$ORGS.sql
+killall postgres
+


### PR DESCRIPTION
Usage:

    docker build -t dump .
    docker run -it --rm -e GITHUB_TOKENS=<token> -v$(pwd):/io dump

The SQL dump should appear in the current directory.

Signed-off-by: Vadim Markovtsev <vadim@athenian.co>




---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [ ] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [ ] This PR contains changes that do not require a mention in the CHANGELOG file
